### PR TITLE
Change class accessibility to internal and sealed

### DIFF
--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/BehaviorBase.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/BehaviorBase.cs
@@ -2,11 +2,15 @@
 
 namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class BehaviorBase<T> : Behavior<T> where T : BindableObject
+	public class BehaviorBase<T> : Behavior<T> where T : BindableObject
     {
         public T AssociatedObject { get; private set; }
 
-        protected override void OnAttachedTo(T bindable)
+		internal BehaviorBase()
+		{
+		}
+
+		protected override void OnAttachedTo(T bindable)
         {
             base.OnAttachedTo(bindable);
             AssociatedObject = bindable;

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingCirclesBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingCirclesBehavior.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class BindingCirclesBehavior : BehaviorBase<Map>
+	public sealed class BindingCirclesBehavior : BehaviorBase<Map>
     {
         private static readonly BindablePropertyKey ValuePropertyKey = BindableProperty.CreateReadOnly("Value", typeof(ObservableCollection<Circle>), typeof(BindingCirclesBehavior), default(ObservableCollection<Circle>));
 

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingGroundOverlaysBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingGroundOverlaysBehavior.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class BindingGroundOverlaysBehavior : BehaviorBase<Map>
+    public sealed class BindingGroundOverlaysBehavior : BehaviorBase<Map>
     {
         private static readonly BindablePropertyKey ValuePropertyKey = BindableProperty.CreateReadOnly("Value", typeof(ObservableCollection<GroundOverlay>), typeof(BindingGroundOverlaysBehavior), default(ObservableCollection<GroundOverlay>));
 

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingPinsBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingPinsBehavior.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class BindingPinsBehavior : BehaviorBase<Map>
+    public sealed class BindingPinsBehavior : BehaviorBase<Map>
     {
         private static readonly BindablePropertyKey ValuePropertyKey = BindableProperty.CreateReadOnly("Value", typeof(ObservableCollection<Pin>), typeof(BindingPinsBehavior), default(ObservableCollection<Pin>));
 

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingPolygonsBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingPolygonsBehavior.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class BindingPolygonsBehavior : BehaviorBase<Map>
+    public sealed class BindingPolygonsBehavior : BehaviorBase<Map>
     {
         private static readonly BindablePropertyKey ValuePropertyKey = BindableProperty.CreateReadOnly("Value", typeof(ObservableCollection<Polygon>), typeof(BindingPolygonsBehavior), default(ObservableCollection<Polygon>));
 

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingPolylinesBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingPolylinesBehavior.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class BindingPolylinesBehavior : BehaviorBase<Map>
+    public sealed class BindingPolylinesBehavior : BehaviorBase<Map>
     {
         private static readonly BindablePropertyKey ValuePropertyKey = BindableProperty.CreateReadOnly("Value", typeof(ObservableCollection<Polyline>), typeof(BindingPolylinesBehavior), default(ObservableCollection<Polyline>));
 

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingTileLayersBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingTileLayersBehavior.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class BindingTileLayersBehavior : BehaviorBase<Map>
+    public sealed class BindingTileLayersBehavior : BehaviorBase<Map>
     {
         private static readonly BindablePropertyKey ValuePropertyKey = BindableProperty.CreateReadOnly("Value", typeof(ObservableCollection<TileLayer>), typeof(BindingTileLayersBehavior), default(ObservableCollection<TileLayer>));
 

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingVisibleRegionBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/BindingVisibleRegionBehavior.cs
@@ -3,7 +3,7 @@
 namespace Xamarin.Forms.GoogleMaps.Bindings
 {
     [Preserve(AllMembers = true)]
-    public class BindingVisibleRegionBehavior : BehaviorBase<Map>
+    public sealed class BindingVisibleRegionBehavior : BehaviorBase<Map>
     {
         private static readonly BindablePropertyKey ValuePropertyKey = BindableProperty.CreateReadOnly("Value", typeof(MapSpan), typeof(BindingVisibleRegionBehavior), default(MapSpan));
 

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/EventToCommandBehaviorBase.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/EventToCommandBehaviorBase.cs
@@ -11,5 +11,9 @@ namespace Xamarin.Forms.GoogleMaps.Bindings
             get { return (ICommand)GetValue(CommandProperty); }
             set { SetValue(CommandProperty, value); }
         }
-    }
+
+		internal EventToCommandBehaviorBase()
+		{
+		}
+	}
 }

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/MapClickedToCommandBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/MapClickedToCommandBehavior.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class MapClickedToCommandBehavior : EventToCommandBehaviorBase
+    public sealed class MapClickedToCommandBehavior : EventToCommandBehaviorBase
     {
         protected override void OnAttachedTo(Map bindable)
         {

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/MapLongClickedToCommandBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/MapLongClickedToCommandBehavior.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class MapLongClickedToCommandBehavior : EventToCommandBehaviorBase
+    public sealed class MapLongClickedToCommandBehavior : EventToCommandBehaviorBase
     {
         protected override void OnAttachedTo(Map bindable)
         {

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/MoveToRegionBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/MoveToRegionBehavior.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class MoveToRegionBehavior : BehaviorBase<Map>
+    public sealed class MoveToRegionBehavior : BehaviorBase<Map>
     {
         public static readonly BindableProperty RequestProperty = BindableProperty.Create("Request", typeof(MoveToRegionRequest), typeof(BindingVisibleRegionBehavior), default(MoveToRegionRequest), propertyChanged:OnRequestChanged);
 

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/MoveToRegionRequest.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/MoveToRegionRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public sealed class MoveToRegionRequest
+	internal sealed class MoveToRegionRequest
     {
         public event EventHandler<MoveToRegionRequestedEventArgs> MoveToRegionRequested;
 

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/MoveToRegionRequest.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/MoveToRegionRequest.cs
@@ -2,9 +2,9 @@
 
 namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-	internal sealed class MoveToRegionRequest
+    public sealed class MoveToRegionRequest
     {
-        public event EventHandler<MoveToRegionRequestedEventArgs> MoveToRegionRequested;
+		internal event EventHandler<MoveToRegionRequestedEventArgs> MoveToRegionRequested;
 
         public void MoveToRegion(MapSpan mapSpan)
         {

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/MoveToRegionRequestedEventArgs.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/MoveToRegionRequestedEventArgs.cs
@@ -4,7 +4,7 @@ namespace Xamarin.Forms.GoogleMaps.Bindings
 {
 	internal sealed class MoveToRegionRequestedEventArgs : EventArgs
     {
-        public MapSpan MapSpan { get; }
+		internal MapSpan MapSpan { get; }
 
 		internal MoveToRegionRequestedEventArgs(MapSpan mapSpan)
         {

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/MoveToRegionRequestedEventArgs.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/MoveToRegionRequestedEventArgs.cs
@@ -2,11 +2,11 @@
 
 namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class MoveToRegionRequestedEventArgs : EventArgs
+	internal sealed class MoveToRegionRequestedEventArgs : EventArgs
     {
         public MapSpan MapSpan { get; }
 
-        public MoveToRegionRequestedEventArgs(MapSpan mapSpan)
+		internal MoveToRegionRequestedEventArgs(MapSpan mapSpan)
         {
             MapSpan = mapSpan;
         }

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/PinClickedToCommandBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/PinClickedToCommandBehavior.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class PinClickedToCommandBehavior : EventToCommandBehaviorBase
+    public sealed class PinClickedToCommandBehavior : EventToCommandBehaviorBase
     {
         protected override void OnAttachedTo(Map bindable)
         {

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/PinDragEndToCommandBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/PinDragEndToCommandBehavior.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class PinDragEndToCommandBehavior : EventToCommandBehaviorBase
+    public sealed class PinDragEndToCommandBehavior : EventToCommandBehaviorBase
     {
         protected override void OnAttachedTo(Map bindable)
         {

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/PinDragStartToCommandBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/PinDragStartToCommandBehavior.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class PinDragStartToCommandBehavior : EventToCommandBehaviorBase
+    public sealed class PinDragStartToCommandBehavior : EventToCommandBehaviorBase
     {
         protected override void OnAttachedTo(Map bindable)
         {

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/PinDraggingToCommandBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/PinDraggingToCommandBehavior.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class PinDraggingToCommandBehavior : EventToCommandBehaviorBase
+    public sealed class PinDraggingToCommandBehavior : EventToCommandBehaviorBase
     {
         protected override void OnAttachedTo(Map bindable)
         {

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/PreserveAttribute.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/PreserveAttribute.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.GoogleMaps.Bindings
         | AttributeTargets.Interface
         | AttributeTargets.Delegate,
         AllowMultiple = true)]
-    public sealed class PreserveAttribute : Attribute
+	internal sealed class PreserveAttribute : Attribute
     {
 
         public bool AllMembers;

--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/SelectedPinChangedToCommandBehavior.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/SelectedPinChangedToCommandBehavior.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms.GoogleMaps.Bindings
 {
-    public class SelectedPinChangedToCommandBehavior : EventToCommandBehaviorBase
+    public sealed class SelectedPinChangedToCommandBehavior : EventToCommandBehaviorBase
     {
         protected override void OnAttachedTo(Map bindable)
         {


### PR DESCRIPTION
外部に公開しないクラスまたはコンストラクタを ``internal`` にして、意図せず内部クラスが使用されないようにしました。

また、公開クラスはとりあえず ``sealed`` にして拡張を禁止しました。
要望があったら徐々に ``sealed`` を外していくのが良いと思います。