### PR TITLE
Removed VerticalOptions="Fill" on Map element

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ public class MainPageViewModel
   <ContentPage.BindingContext>
     <local:MainPageViewModel/>
   </ContentPage.BindingContext>
-  <googleMaps:Map VerticalOptions="Fill">
+  <googleMaps:Map>
     <googleMaps:Map.Behaviors>
       <bindings:BindingPinsBehavior Value="{Binding Pins}"/>
       <bindings:MapClickedToCommandBehavior Command="{Binding MapClickedCommand}"/>


### PR DESCRIPTION
for me this specifically drove an all white blank display vs not setting a value or setting FillAndExpand.
running on latest stable versions of all nugets as of this date = Xamarin.Forms v2.3.3.193, Xamarin.Forms.GoogleMaps v1.7.1, Xamarin.Forms.GoogleMaps.Bindings v1.0.1, Xamarin.Google.iOS.Maps v2.1.0.1