### PR TITLE
I made the command property public.

### DIFF
--- a/Source/Xamarin.Forms.GoogleMaps.Bindings/EventToCommandBehaviorBase.cs
+++ b/Source/Xamarin.Forms.GoogleMaps.Bindings/EventToCommandBehaviorBase.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Forms.GoogleMaps.Bindings
     {
         public static readonly BindableProperty CommandProperty = BindableProperty.Create("Command", typeof(ICommand), typeof(MapClickedToCommandBehavior), default(ICommand));
 
-        protected ICommand Command
+        public ICommand Command
         {
             get => (ICommand)GetValue(CommandProperty);
             set => SetValue(CommandProperty, value);


### PR DESCRIPTION
The command property was marked as "protected" so it did not appear in intellisense XAML and binding could not be done to it via the view model's command